### PR TITLE
fix: Removing duplicate date in left panel

### DIFF
--- a/map/public/js/main.js
+++ b/map/public/js/main.js
@@ -161,10 +161,18 @@ async function showLayer(input, customMinMax) {
 
     // Add
     input.layer.addTo(map);
-    document.getElementById("tiff-name").innerText = input.tiff.description;
+
+    // Fixing duplicate date
+    const dateInput = input.tiff.date;
+    const mm = (dateInput.getUTCMonth() + 1).toString().padStart(2, "0");
+    const dd = dateInput.getUTCDate().toString().padStart(2, "0");
+    const yyyy = dateInput.getUTCFullYear();
+    const hour = dateInput.getHours().toString().padStart(2, "0");
+    document.getElementById("tiff-name").innerText = dateInput ? `${mm}-${dd}-${yyyy} ${hour}:00 UTC` : input.tiff.description;
+
     if (!customMinMax) {
         updateMinMax(input.tiff.min, input.tiff.max);
-    }
+    } // if 
 
     if (input.tiff.hurricaneLayer != null) {
         input.tiff.hurricaneLayer.hurrLayer.addTo(hurricaneLayer);

--- a/map/src/components/Sidebar.js
+++ b/map/src/components/Sidebar.js
@@ -18,11 +18,11 @@ const Sidebar = () => {
                 <a href="https://coast.engr.uga.edu/">UGA Coast Website</a>
                 <div id="version-container">
                     <b id="version-label">Version:</b>
-                    <text id="version">Loading</text>
+                    <span id="version">Loading</span>
                 </div>
                 <hr></hr>
                 <div>
-                    <text id="tiff-name">Select a tiff to start</text>
+                    <span id="tiff-name">Select a tiff to start</span>
                 </div>
             </div>
             <div id="controls">


### PR DESCRIPTION
## Description
Removed duplicate date (ex: 03-30-2026 12:00 UTC--2026-03-30T12:00:00) to display date once (03-30-2026 12:00 UTC). 
<img width="1917" height="970" alt="image" src="https://github.com/user-attachments/assets/a3fa798e-3835-47b0-892e-60accc06f455" />
